### PR TITLE
Updated Name of SMS-Quickstart Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ This microservice is used to connect the Hifu API to Twilio SMS text messaging s
       - ``200`` Success / Text Message sent
       - ``500`` Error / Text Message not sent
 
-  - `sms-quickstart`
+  - `reply`
     - Description: Set up to handle any message that comes in to our Twilio phone number.
     - Additional Information: This endpoint shouldn't really need to be used by Hifu devs, but allows outside users to receive a response of 'Please check your email for more information. This phone number is not monitored' if they reply to our alert text message.

--- a/microservice.rb
+++ b/microservice.rb
@@ -35,7 +35,7 @@ Dotenv.load
     end
   end
 
-  post '/sms-quickstart' do
+  post '/reply' do
     twiml = Twilio::TwiML::MessagingResponse.new do |r|
       r.message(body: 'Please check your email for more information. This phone number is not monitored.')
     end

--- a/test/test.rb
+++ b/test/test.rb
@@ -36,7 +36,7 @@ class MicroserviceTest < MiniTest::Unit::TestCase
   end
 
   def test_reply_functionality
-    post '/sms-quickstart'
+    post '/reply'
     assert last_response.ok?
     assert last_response.body.include?("Please check your email for more information. This phone number is not monitored.")
   end


### PR DESCRIPTION
Changed name of `sms-quickstart` endpoint to `reply` to be more descriptive. Also updated console on Twilio to reflect changes to endpoint name.

Ran test suite and all tests are still passing, also deployed update-quickstart branch to Heroku and manually tested that reply messages are still being sent.